### PR TITLE
add caret before version number when using yarn

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,10 @@ const outdated = require('./libs/outdated');
 const reStylingJson = require('./libs/reStylingJson');
 const filterPackageBySemVer = require('./libs/filterPackageBySemVer');
 
-const UPDATE_COMMAND = {
-  npm: 'install',
-  yarn: 'add'
+const buildUpdateCommand = (manager, type, name, version) => {
+  const flags = type === 'devDependencies' ? '-D ' : '';
+  if (manager === 'npm') return `npm install ${flags}${name}@${version}`;
+  if (manager === 'yarn') return `yarn add ${flags}${name}@^${version}`;
 };
 const RESET_COMMAND = {
   npm: 'npm ci',
@@ -69,7 +70,7 @@ module.exports = (updateSemVer, flags = {}, options = {}) => {
   let success = [];
   let errors = [];
 
-  execCommand(RESET_COMMAND[manager]);  
+  execCommand(RESET_COMMAND[manager]);
   if (options.prepare) execCommand(options.prepare);
 
   Object.keys(outdatedJson)
@@ -88,7 +89,7 @@ module.exports = (updateSemVer, flags = {}, options = {}) => {
         DEPS_TYPE: type
       };
 
-      const command = `${manager} ${UPDATE_COMMAND[manager]} ${type === 'devDependencies' ? '-D ' : ''}${name}@${goto}`;
+      const command = buildUpdateCommand(manager, type, name, goto);
       try {
         console.info('RUN:', command);
         if (!process.env.DEBUG) execCommand(command, replace);


### PR DESCRIPTION
When using yarn, `safety-updater` executes `yarn add <pkg>@1.2.3`, but it writes the exact version number `"1.2.3"` to package.json, while `npm i <pkg>@1.2.3` writes `"^1.2.3"`.
Because `safety-updater` does not update a package with exact version number, packages updated at the first run of `safety-updater` will not be updated at the second time.
We have to use `yarn add <pkg>@^1.2.3`, caret before version numbers, to update packages continuously.

EDIT: I am using yarn@1.3.0, which is the current latest version.

